### PR TITLE
explicit directory locations of slurm_logs and cd in one_wag job script

### DIFF
--- a/wags/prep_subs.py
+++ b/wags/prep_subs.py
@@ -348,8 +348,8 @@ def main():
             "#SBATCH --mail-type=ALL\n"
             f"#SBATCH --mail-user={email}\n"
             f"#SBATCH --job-name {v['breed']}_{k}.{job_name}.{profile}\n"
-            f"#SBATCH -o slurm_logs/%j.{v['breed']}_{k}.{job_name}.out\n"
-            f"#SBATCH -e slurm_logs/%j.{v['breed']}_{k}.{job_name}.err\n"
+            f"#SBATCH -o {v['work_dir']}/slurm_logs/%j.{v['breed']}_{k}.{job_name}.out\n"
+            f"#SBATCH -e {v['work_dir']}/slurm_logs/%j.{v['breed']}_{k}.{job_name}.err\n"
             f"#SBATCH -A {account}\n"
             f"#SBATCH -p {partition}\n"
         )             
@@ -374,7 +374,7 @@ def main():
             print("set -e\n",file=f)
             print(f"conda activate {snake_env}",file=f)
             if profile != 'lsf':
-                print("cd $SLURM_SUBMIT_DIR\n",file=f)
+                print(f"cd {v['work_dir']}\n",file=f)
 
             if ref not in refs:
                 print(f"REF_DIR={ref_dir}",end="",file=f)


### PR DESCRIPTION
Uses the existing work_dir variable to make the slurm_logs directory locations and initial cd to set the slurm job working directory explicit as inside the folder generated by prep_subs.py. Previous behavior made the slurm job working directory the working directory of the user when a slurm job is submitted.

This change should allow users to submit the slurm script generated by one_wag's prep_subs.py via sbatch even when their working directory isn't in the specific generated folder for that sample.

(tested on four random breed canfam3 jobs)