### PR TITLE
Add the ability to process single-end reads

### DIFF
--- a/pipelines/one_wag/inputs/local/bqsr/rules/bam.smk
+++ b/pipelines/one_wag/inputs/local/bqsr/rules/bam.smk
@@ -21,21 +21,41 @@ rule fastqs_to_ubam:
          mem_mb = lambda wildcards, attempt: 2**(attempt-1)*40000,
     shell:
         '''
-            mkdir -p {params.tmp_dir}
+            if [ {input.r1} == {input.r2} ]; then
+                echo "Processing {wildcards.sample_name} as SINGLE"
 
-            gatk --java-options {params.java_opt} \
-                FastqToSam \
-                --TMP_DIR {params.tmp_dir} \
-                --FASTQ {input.r1} \
-                --FASTQ2 {input.r2} \
-                --OUTPUT {output.ubam} \
-                --READ_GROUP_NAME {wildcards.readgroup_name} \
-                --SAMPLE_NAME {wildcards.sample_name} \
-                --LIBRARY_NAME {params.library_name} \
-                --PLATFORM_UNIT {params.platform_unit} \
-                --RUN_DATE {params.run_date} \
-                --PLATFORM {params.platform_name} \
-                --SEQUENCING_CENTER {params.sequencing_center}
+                mkdir -p {params.tmp_dir}
+
+                gatk --java-options {params.java_opt} \
+                    FastqToSam \
+                    --TMP_DIR {params.tmp_dir} \
+                    --FASTQ {input.r1} \
+                    --OUTPUT {output.ubam} \
+                    --READ_GROUP_NAME {wildcards.readgroup_name} \
+                    --SAMPLE_NAME {wildcards.sample_name} \
+                    --LIBRARY_NAME {params.library_name} \
+                    --PLATFORM_UNIT {params.platform_unit} \
+                    --RUN_DATE {params.run_date} \
+                    --PLATFORM {params.platform_name} \
+                    --SEQUENCING_CENTER {params.sequencing_center}
+            else
+                echo "Procesing {wildcards.sample_name} as PAIRED"
+                mkdir -p {params.tmp_dir}
+
+                gatk --java-options {params.java_opt} \
+                    FastqToSam \
+                    --TMP_DIR {params.tmp_dir} \
+                    --FASTQ {input.r1} \
+                    --FASTQ2 {input.r2} \
+                    --OUTPUT {output.ubam} \
+                    --READ_GROUP_NAME {wildcards.readgroup_name} \
+                    --SAMPLE_NAME {wildcards.sample_name} \
+                    --LIBRARY_NAME {params.library_name} \
+                    --PLATFORM_UNIT {params.platform_unit} \
+                    --RUN_DATE {params.run_date} \
+                    --PLATFORM {params.platform_name} \
+                    --SEQUENCING_CENTER {params.sequencing_center}
+            fi
         '''
 
 rule mark_adapters:

--- a/pipelines/one_wag/inputs/local/bqsr/rules/qc.smk
+++ b/pipelines/one_wag/inputs/local/bqsr/rules/qc.smk
@@ -23,14 +23,28 @@ rule fastqc:
         '''
             set -e
 
-            fastqc -t {threads} \
-                --outdir {params.outdir} \
-                {input.r1} {input.r2}
+            if [ {input.r1} == {input.r2} ]; then
+                echo "Processing {wildcards.sample_name} as SINGLE"
 
-            mv {params.outdir}/{params.r1_html} {output.r1_html}
-            mv {params.outdir}/{params.r2_html} {output.r2_html}
-            mv {params.outdir}/{params.r1_zip} {output.r1_zip}
-            mv {params.outdir}/{params.r2_zip} {output.r2_zip}
+                fastqc -t {threads} \
+                    --outdir {params.outdir} \
+                    {input.r1}
+
+                touch {output.r2_html} {output.r2_zip} # Create empty files
+                mv {params.outdir}/{params.r1_html} {output.r1_html}
+                mv {params.outdir}/{params.r1_zip} {output.r1_zip}
+            else
+                echo "Processing {wildcards.sample_name} as PAIRED"
+
+                fastqc -t {threads} \
+                    --outdir {params.outdir} \
+                    {input.r1} {input.r2}
+
+                mv {params.outdir}/{params.r1_html} {output.r1_html}
+                mv {params.outdir}/{params.r2_html} {output.r2_html}
+                mv {params.outdir}/{params.r1_zip} {output.r1_zip}
+                mv {params.outdir}/{params.r2_zip} {output.r2_zip}
+            fi
         '''
 
 rule flagstat:

--- a/pipelines/one_wag/inputs/local/no_bqsr/rules/bam.smk
+++ b/pipelines/one_wag/inputs/local/no_bqsr/rules/bam.smk
@@ -21,21 +21,41 @@ rule fastqs_to_ubam:
          mem_mb = lambda wildcards, attempt: 2**(attempt-1)*40000,
     shell:
         '''
-            mkdir -p {params.tmp_dir}
+            if [ {input.r1} == {input.r2} ]; then
+                echo "Processing {wildcards.sample_name} as SINGLE"
 
-            gatk --java-options {params.java_opt} \
-                FastqToSam \
-                --TMP_DIR {params.tmp_dir} \
-                --FASTQ {input.r1} \
-                --FASTQ2 {input.r2} \
-                --OUTPUT {output.ubam} \
-                --READ_GROUP_NAME {wildcards.readgroup_name} \
-                --SAMPLE_NAME {wildcards.sample_name} \
-                --LIBRARY_NAME {params.library_name} \
-                --PLATFORM_UNIT {params.platform_unit} \
-                --RUN_DATE {params.run_date} \
-                --PLATFORM {params.platform_name} \
-                --SEQUENCING_CENTER {params.sequencing_center}
+                mkdir -p {params.tmp_dir}
+
+                gatk --java-options {params.java_opt} \
+                    FastqToSam \
+                    --TMP_DIR {params.tmp_dir} \
+                    --FASTQ {input.r1} \
+                    --OUTPUT {output.ubam} \
+                    --READ_GROUP_NAME {wildcards.readgroup_name} \
+                    --SAMPLE_NAME {wildcards.sample_name} \
+                    --LIBRARY_NAME {params.library_name} \
+                    --PLATFORM_UNIT {params.platform_unit} \
+                    --RUN_DATE {params.run_date} \
+                    --PLATFORM {params.platform_name} \
+                    --SEQUENCING_CENTER {params.sequencing_center}
+            else
+                echo "Procesing {wildcards.sample_name} as PAIRED"
+                mkdir -p {params.tmp_dir}
+
+                gatk --java-options {params.java_opt} \
+                    FastqToSam \
+                    --TMP_DIR {params.tmp_dir} \
+                    --FASTQ {input.r1} \
+                    --FASTQ2 {input.r2} \
+                    --OUTPUT {output.ubam} \
+                    --READ_GROUP_NAME {wildcards.readgroup_name} \
+                    --SAMPLE_NAME {wildcards.sample_name} \
+                    --LIBRARY_NAME {params.library_name} \
+                    --PLATFORM_UNIT {params.platform_unit} \
+                    --RUN_DATE {params.run_date} \
+                    --PLATFORM {params.platform_name} \
+                    --SEQUENCING_CENTER {params.sequencing_center}
+            fi
         '''
 
 rule mark_adapters:

--- a/pipelines/one_wag/inputs/local/no_bqsr/rules/qc.smk
+++ b/pipelines/one_wag/inputs/local/no_bqsr/rules/qc.smk
@@ -23,14 +23,28 @@ rule fastqc:
         '''
             set -e
 
-            fastqc -t {threads} \
-                --outdir {params.outdir} \
-                {input.r1} {input.r2}
+            if [ {input.r1} == {input.r2} ]; then
+                echo "Processing {wildcards.sample_name} as SINGLE"
 
-            mv {params.outdir}/{params.r1_html} {output.r1_html}
-            mv {params.outdir}/{params.r2_html} {output.r2_html}
-            mv {params.outdir}/{params.r1_zip} {output.r1_zip}
-            mv {params.outdir}/{params.r2_zip} {output.r2_zip}
+                fastqc -t {threads} \
+                    --outdir {params.outdir} \
+                    {input.r1}
+
+                touch {output.r2_html} {output.r2_zip} # Create empty files
+                mv {params.outdir}/{params.r1_html} {output.r1_html}
+                mv {params.outdir}/{params.r1_zip} {output.r1_zip}
+            else
+                echo "Processing {wildcards.sample_name} as PAIRED"
+
+                fastqc -t {threads} \
+                    --outdir {params.outdir} \
+                    {input.r1} {input.r2}
+
+                mv {params.outdir}/{params.r1_html} {output.r1_html}
+                mv {params.outdir}/{params.r2_html} {output.r2_html}
+                mv {params.outdir}/{params.r1_zip} {output.r1_zip}
+                mv {params.outdir}/{params.r2_zip} {output.r2_zip}
+            fi
         '''
 
 rule flagstat:

--- a/pipelines/one_wag/inputs/s3/bqsr/rules/bam.smk
+++ b/pipelines/one_wag/inputs/s3/bqsr/rules/bam.smk
@@ -21,21 +21,41 @@ rule fastqs_to_ubam:
          mem_mb = lambda wildcards, attempt: 2**(attempt-1)*40000,
     shell:
         '''
-            mkdir -p {params.tmp_dir}
+            if [ {input.r1} == {input.r2} ]; then
+                echo "Processing {wildcards.sample_name} as SINGLE"
 
-            gatk --java-options {params.java_opt} \
-                FastqToSam \
-                --TMP_DIR {params.tmp_dir} \
-                --FASTQ {input.r1} \
-                --FASTQ2 {input.r2} \
-                --OUTPUT {output.ubam} \
-                --READ_GROUP_NAME {wildcards.readgroup_name} \
-                --SAMPLE_NAME {wildcards.sample_name} \
-                --LIBRARY_NAME {params.library_name} \
-                --PLATFORM_UNIT {params.platform_unit} \
-                --RUN_DATE {params.run_date} \
-                --PLATFORM {params.platform_name} \
-                --SEQUENCING_CENTER {params.sequencing_center}
+                mkdir -p {params.tmp_dir}
+
+                gatk --java-options {params.java_opt} \
+                    FastqToSam \
+                    --TMP_DIR {params.tmp_dir} \
+                    --FASTQ {input.r1} \
+                    --OUTPUT {output.ubam} \
+                    --READ_GROUP_NAME {wildcards.readgroup_name} \
+                    --SAMPLE_NAME {wildcards.sample_name} \
+                    --LIBRARY_NAME {params.library_name} \
+                    --PLATFORM_UNIT {params.platform_unit} \
+                    --RUN_DATE {params.run_date} \
+                    --PLATFORM {params.platform_name} \
+                    --SEQUENCING_CENTER {params.sequencing_center}
+            else
+                echo "Procesing {wildcards.sample_name} as PAIRED"
+                mkdir -p {params.tmp_dir}
+
+                gatk --java-options {params.java_opt} \
+                    FastqToSam \
+                    --TMP_DIR {params.tmp_dir} \
+                    --FASTQ {input.r1} \
+                    --FASTQ2 {input.r2} \
+                    --OUTPUT {output.ubam} \
+                    --READ_GROUP_NAME {wildcards.readgroup_name} \
+                    --SAMPLE_NAME {wildcards.sample_name} \
+                    --LIBRARY_NAME {params.library_name} \
+                    --PLATFORM_UNIT {params.platform_unit} \
+                    --RUN_DATE {params.run_date} \
+                    --PLATFORM {params.platform_name} \
+                    --SEQUENCING_CENTER {params.sequencing_center}
+            fi
         '''
 
 rule mark_adapters:

--- a/pipelines/one_wag/inputs/s3/bqsr/rules/qc.smk
+++ b/pipelines/one_wag/inputs/s3/bqsr/rules/qc.smk
@@ -23,14 +23,28 @@ rule fastqc:
         '''
             set -e
 
-            fastqc -t {threads} \
-                --outdir {params.outdir} \
-                {input.r1} {input.r2}
+            if [ {input.r1} == {input.r2} ]; then
+                echo "Processing {wildcards.sample_name} as SINGLE"
 
-            mv {params.outdir}/{params.r1_html} {output.r1_html}
-            mv {params.outdir}/{params.r2_html} {output.r2_html}
-            mv {params.outdir}/{params.r1_zip} {output.r1_zip}
-            mv {params.outdir}/{params.r2_zip} {output.r2_zip}
+                fastqc -t {threads} \
+                    --outdir {params.outdir} \
+                    {input.r1}
+
+                touch {output.r2_html} {output.r2_zip} # Create empty files
+                mv {params.outdir}/{params.r1_html} {output.r1_html}
+                mv {params.outdir}/{params.r1_zip} {output.r1_zip}
+            else
+                echo "Processing {wildcards.sample_name} as PAIRED"
+
+                fastqc -t {threads} \
+                    --outdir {params.outdir} \
+                    {input.r1} {input.r2}
+
+                mv {params.outdir}/{params.r1_html} {output.r1_html}
+                mv {params.outdir}/{params.r2_html} {output.r2_html}
+                mv {params.outdir}/{params.r1_zip} {output.r1_zip}
+                mv {params.outdir}/{params.r2_zip} {output.r2_zip}
+            fi
         '''
 
 rule flagstat:

--- a/pipelines/one_wag/inputs/s3/no_bqsr/rules/bam.smk
+++ b/pipelines/one_wag/inputs/s3/no_bqsr/rules/bam.smk
@@ -21,21 +21,41 @@ rule fastqs_to_ubam:
          mem_mb = lambda wildcards, attempt: 2**(attempt-1)*40000,
     shell:
         '''
-            mkdir -p {params.tmp_dir}
+            if [ {input.r1} == {input.r2} ]; then
+                echo "Processing {wildcards.sample_name} as SINGLE"
 
-            gatk --java-options {params.java_opt} \
-                FastqToSam \
-                --TMP_DIR {params.tmp_dir} \
-                --FASTQ {input.r1} \
-                --FASTQ2 {input.r2} \
-                --OUTPUT {output.ubam} \
-                --READ_GROUP_NAME {wildcards.readgroup_name} \
-                --SAMPLE_NAME {wildcards.sample_name} \
-                --LIBRARY_NAME {params.library_name} \
-                --PLATFORM_UNIT {params.platform_unit} \
-                --RUN_DATE {params.run_date} \
-                --PLATFORM {params.platform_name} \
-                --SEQUENCING_CENTER {params.sequencing_center}
+                mkdir -p {params.tmp_dir}
+
+                gatk --java-options {params.java_opt} \
+                    FastqToSam \
+                    --TMP_DIR {params.tmp_dir} \
+                    --FASTQ {input.r1} \
+                    --OUTPUT {output.ubam} \
+                    --READ_GROUP_NAME {wildcards.readgroup_name} \
+                    --SAMPLE_NAME {wildcards.sample_name} \
+                    --LIBRARY_NAME {params.library_name} \
+                    --PLATFORM_UNIT {params.platform_unit} \
+                    --RUN_DATE {params.run_date} \
+                    --PLATFORM {params.platform_name} \
+                    --SEQUENCING_CENTER {params.sequencing_center}
+            else
+                echo "Procesing {wildcards.sample_name} as PAIRED"
+                mkdir -p {params.tmp_dir}
+
+                gatk --java-options {params.java_opt} \
+                    FastqToSam \
+                    --TMP_DIR {params.tmp_dir} \
+                    --FASTQ {input.r1} \
+                    --FASTQ2 {input.r2} \
+                    --OUTPUT {output.ubam} \
+                    --READ_GROUP_NAME {wildcards.readgroup_name} \
+                    --SAMPLE_NAME {wildcards.sample_name} \
+                    --LIBRARY_NAME {params.library_name} \
+                    --PLATFORM_UNIT {params.platform_unit} \
+                    --RUN_DATE {params.run_date} \
+                    --PLATFORM {params.platform_name} \
+                    --SEQUENCING_CENTER {params.sequencing_center}
+            fi
         '''
 
 rule mark_adapters:

--- a/pipelines/one_wag/inputs/s3/no_bqsr/rules/qc.smk
+++ b/pipelines/one_wag/inputs/s3/no_bqsr/rules/qc.smk
@@ -23,14 +23,28 @@ rule fastqc:
         '''
             set -e
 
-            fastqc -t {threads} \
-                --outdir {params.outdir} \
-                {input.r1} {input.r2}
+            if [ {input.r1} == {input.r2} ]; then
+                echo "Processing {wildcards.sample_name} as SINGLE"
 
-            mv {params.outdir}/{params.r1_html} {output.r1_html}
-            mv {params.outdir}/{params.r2_html} {output.r2_html}
-            mv {params.outdir}/{params.r1_zip} {output.r1_zip}
-            mv {params.outdir}/{params.r2_zip} {output.r2_zip}
+                fastqc -t {threads} \
+                    --outdir {params.outdir} \
+                    {input.r1}
+
+                touch {output.r2_html} {output.r2_zip} # Create empty files
+                mv {params.outdir}/{params.r1_html} {output.r1_html}
+                mv {params.outdir}/{params.r1_zip} {output.r1_zip}
+            else
+                echo "Processing {wildcards.sample_name} as PAIRED"
+
+                fastqc -t {threads} \
+                    --outdir {params.outdir} \
+                    {input.r1} {input.r2}
+
+                mv {params.outdir}/{params.r1_html} {output.r1_html}
+                mv {params.outdir}/{params.r2_html} {output.r2_html}
+                mv {params.outdir}/{params.r1_zip} {output.r1_zip}
+                mv {params.outdir}/{params.r2_zip} {output.r2_zip}
+            fi
         '''
 
 rule flagstat:

--- a/pipelines/one_wag/inputs/sftp/bqsr/rules/bam.smk
+++ b/pipelines/one_wag/inputs/sftp/bqsr/rules/bam.smk
@@ -22,21 +22,41 @@ rule fastqs_to_ubam:
          mem_mb = lambda wildcards, attempt: 2**(attempt-1)*40000,
     shell:
         '''
-            mkdir -p {params.tmp_dir}
+            if [ {input.r1} == {input.r2} ]; then
+                echo "Processing {wildcards.sample_name} as SINGLE"
 
-            gatk --java-options {params.java_opt} \
-                FastqToSam \
-                --TMP_DIR {params.tmp_dir} \
-                --FASTQ {input.r1} \
-                --FASTQ2 {input.r2} \
-                --OUTPUT {output.ubam} \
-                --READ_GROUP_NAME {wildcards.readgroup_name} \
-                --SAMPLE_NAME {wildcards.sample_name} \
-                --LIBRARY_NAME {params.library_name} \
-                --PLATFORM_UNIT {params.platform_unit} \
-                --RUN_DATE {params.run_date} \
-                --PLATFORM {params.platform_name} \
-                --SEQUENCING_CENTER {params.sequencing_center}
+                mkdir -p {params.tmp_dir}
+
+                gatk --java-options {params.java_opt} \
+                    FastqToSam \
+                    --TMP_DIR {params.tmp_dir} \
+                    --FASTQ {input.r1} \
+                    --OUTPUT {output.ubam} \
+                    --READ_GROUP_NAME {wildcards.readgroup_name} \
+                    --SAMPLE_NAME {wildcards.sample_name} \
+                    --LIBRARY_NAME {params.library_name} \
+                    --PLATFORM_UNIT {params.platform_unit} \
+                    --RUN_DATE {params.run_date} \
+                    --PLATFORM {params.platform_name} \
+                    --SEQUENCING_CENTER {params.sequencing_center}
+            else
+                echo "Procesing {wildcards.sample_name} as PAIRED"
+                mkdir -p {params.tmp_dir}
+
+                gatk --java-options {params.java_opt} \
+                    FastqToSam \
+                    --TMP_DIR {params.tmp_dir} \
+                    --FASTQ {input.r1} \
+                    --FASTQ2 {input.r2} \
+                    --OUTPUT {output.ubam} \
+                    --READ_GROUP_NAME {wildcards.readgroup_name} \
+                    --SAMPLE_NAME {wildcards.sample_name} \
+                    --LIBRARY_NAME {params.library_name} \
+                    --PLATFORM_UNIT {params.platform_unit} \
+                    --RUN_DATE {params.run_date} \
+                    --PLATFORM {params.platform_name} \
+                    --SEQUENCING_CENTER {params.sequencing_center}
+            fi
         '''
 
 rule mark_adapters:

--- a/pipelines/one_wag/inputs/sftp/bqsr/rules/qc.smk
+++ b/pipelines/one_wag/inputs/sftp/bqsr/rules/qc.smk
@@ -23,14 +23,28 @@ rule fastqc:
         '''
             set -e
 
-            fastqc -t {threads} \
-                --outdir {params.outdir} \
-                {input.r1} {input.r2}
+            if [ {input.r1} == {input.r2} ]; then
+                echo "Processing {wildcards.sample_name} as SINGLE"
 
-            mv {params.outdir}/{params.r1_html} {output.r1_html}
-            mv {params.outdir}/{params.r2_html} {output.r2_html}
-            mv {params.outdir}/{params.r1_zip} {output.r1_zip}
-            mv {params.outdir}/{params.r2_zip} {output.r2_zip}
+                fastqc -t {threads} \
+                    --outdir {params.outdir} \
+                    {input.r1}
+
+                touch {output.r2_html} {output.r2_zip} # Create empty files
+                mv {params.outdir}/{params.r1_html} {output.r1_html}
+                mv {params.outdir}/{params.r1_zip} {output.r1_zip}
+            else
+                echo "Processing {wildcards.sample_name} as PAIRED"
+
+                fastqc -t {threads} \
+                    --outdir {params.outdir} \
+                    {input.r1} {input.r2}
+
+                mv {params.outdir}/{params.r1_html} {output.r1_html}
+                mv {params.outdir}/{params.r2_html} {output.r2_html}
+                mv {params.outdir}/{params.r1_zip} {output.r1_zip}
+                mv {params.outdir}/{params.r2_zip} {output.r2_zip}
+            fi
         '''
 
 rule flagstat:

--- a/pipelines/one_wag/inputs/sftp/no_bqsr/rules/bam.smk
+++ b/pipelines/one_wag/inputs/sftp/no_bqsr/rules/bam.smk
@@ -22,21 +22,41 @@ rule fastqs_to_ubam:
          mem_mb = lambda wildcards, attempt: 2**(attempt-1)*60000,
     shell:
         '''
-            mkdir -p {params.tmp_dir}
+            if [ {input.r1} == {input.r2} ]; then
+                echo "Processing {wildcards.sample_name} as SINGLE"
 
-            gatk --java-options {params.java_opt} \
-                FastqToSam \
-                --TMP_DIR {params.tmp_dir} \
-                --FASTQ {input.r1} \
-                --FASTQ2 {input.r2} \
-                --OUTPUT {output.ubam} \
-                --READ_GROUP_NAME {wildcards.readgroup_name} \
-                --SAMPLE_NAME {wildcards.sample_name} \
-                --LIBRARY_NAME {params.library_name} \
-                --PLATFORM_UNIT {params.platform_unit} \
-                --RUN_DATE {params.run_date} \
-                --PLATFORM {params.platform_name} \
-                --SEQUENCING_CENTER {params.sequencing_center}
+                mkdir -p {params.tmp_dir}
+
+                gatk --java-options {params.java_opt} \
+                    FastqToSam \
+                    --TMP_DIR {params.tmp_dir} \
+                    --FASTQ {input.r1} \
+                    --OUTPUT {output.ubam} \
+                    --READ_GROUP_NAME {wildcards.readgroup_name} \
+                    --SAMPLE_NAME {wildcards.sample_name} \
+                    --LIBRARY_NAME {params.library_name} \
+                    --PLATFORM_UNIT {params.platform_unit} \
+                    --RUN_DATE {params.run_date} \
+                    --PLATFORM {params.platform_name} \
+                    --SEQUENCING_CENTER {params.sequencing_center}
+            else
+                echo "Procesing {wildcards.sample_name} as PAIRED"
+                mkdir -p {params.tmp_dir}
+
+                gatk --java-options {params.java_opt} \
+                    FastqToSam \
+                    --TMP_DIR {params.tmp_dir} \
+                    --FASTQ {input.r1} \
+                    --FASTQ2 {input.r2} \
+                    --OUTPUT {output.ubam} \
+                    --READ_GROUP_NAME {wildcards.readgroup_name} \
+                    --SAMPLE_NAME {wildcards.sample_name} \
+                    --LIBRARY_NAME {params.library_name} \
+                    --PLATFORM_UNIT {params.platform_unit} \
+                    --RUN_DATE {params.run_date} \
+                    --PLATFORM {params.platform_name} \
+                    --SEQUENCING_CENTER {params.sequencing_center}
+            fi
         '''
 
 rule mark_adapters:

--- a/pipelines/one_wag/inputs/sftp/no_bqsr/rules/qc.smk
+++ b/pipelines/one_wag/inputs/sftp/no_bqsr/rules/qc.smk
@@ -23,14 +23,28 @@ rule fastqc:
         '''
             set -e
 
-            fastqc -t {threads} \
-                --outdir {params.outdir} \
-                {input.r1} {input.r2}
+            if [ {input.r1} == {input.r2} ]; then
+                echo "Processing {wildcards.sample_name} as SINGLE"
 
-            mv {params.outdir}/{params.r1_html} {output.r1_html}
-            mv {params.outdir}/{params.r2_html} {output.r2_html}
-            mv {params.outdir}/{params.r1_zip} {output.r1_zip}
-            mv {params.outdir}/{params.r2_zip} {output.r2_zip}
+                fastqc -t {threads} \
+                    --outdir {params.outdir} \
+                    {input.r1}
+
+                touch {output.r2_html} {output.r2_zip} # Create empty files
+                mv {params.outdir}/{params.r1_html} {output.r1_html}
+                mv {params.outdir}/{params.r1_zip} {output.r1_zip}
+            else
+                echo "Processing {wildcards.sample_name} as PAIRED"
+
+                fastqc -t {threads} \
+                    --outdir {params.outdir} \
+                    {input.r1} {input.r2}
+
+                mv {params.outdir}/{params.r1_html} {output.r1_html}
+                mv {params.outdir}/{params.r2_html} {output.r2_html}
+                mv {params.outdir}/{params.r1_zip} {output.r1_zip}
+                mv {params.outdir}/{params.r2_zip} {output.r2_zip}
+            fi
         '''
 
 rule flagstat:


### PR DESCRIPTION
These edits enable "prep_subs.py" to identify if a FASTQ is paired-end or single-end. If the FASTQ is single-end, the name of the R1 FASTQ file will be entered into the "fastq_2" column of "input.tsv". The "bam.smk" and "qc.smk" pipelines are then able to detect this and the files are processed as single-end in the "fastqs_to_ubam" rule and in the "fastqc" rule. This will allow for streamlined processing of single-end and paired-end FASTQs together without error.