### PR TITLE
Update final_output.smk to conform to new xlsxwriter syntax

### DIFF
--- a/pipelines/only_wag/inputs/s3/bqsr/rules/final_output.smk
+++ b/pipelines/only_wag/inputs/s3/bqsr/rules/final_output.smk
@@ -51,16 +51,16 @@ rule final_output:
         # write each df to the same excel sheet
         with pd.ExcelWriter(
                 output.excel_sheet,
-                engine="xlsxwriter",
-                options={"strings_to_formulas": False}
+                engine="xlsxwriter"
             ) as writer:
+            writer.book.strings_to_formulas = False
             for k,v in dfs.items():
                 v.to_excel(
                     writer,
                     sheet_name=k.split('.')[-1],
                     index=False
                 )
-            writer.save()
+            writer.close()
 
 rule manifest_and_archive:
     input:


### PR DESCRIPTION
Updates options strings_to_formulas and writer.save() calls to fit new xlsxwriter syntax/behavior.

Previous behavior broke due to the depreciation and replacement of xlsxwriter's .save() method with .close(). Previous passing of options={"strings_to_formulas": False} in pd.ExcelWriter also failed due to options not being an allowed argument likely due to behavior changes also in xlsxwriter.

The new line 56 attempts to replicate the strings_to_formula behavior.