### PR TITLE
Remove unused `phylop` parameter from gather_and_vep

### DIFF
--- a/pipelines/only_wag/inputs/local/bqsr/rules/gather_and_vep.smk
+++ b/pipelines/only_wag/inputs/local/bqsr/rules/gather_and_vep.smk
@@ -31,14 +31,13 @@ rule vep_by_interval:
         interval  = "{bucket}/wgs/{breed}/{sample_name}/{ref}/gvcf/hc_intervals/scattered/{vep_interval}-scattered.interval_list"
     output:
         final_interval    = "{bucket}/wgs/{breed}/{sample_name}/{ref}/money/final_gather/split/wags_{vep_interval}/{sample_name}.{vep_interval}.vcf.gz",
-        interval_vep      = "{bucket}/wgs/{breed}/{sample_name}/{ref}/money/final_gather/vep/wags_{vep_interval}/{sample_name}.{vep_interval}.vep.vcf.gz", 
-        interval_vep_tbi  = "{bucket}/wgs/{breed}/{sample_name}/{ref}/money/final_gather/vep/wags_{vep_interval}/{sample_name}.{vep_interval}.vep.vcf.gz.tbi", 
-        interval_vep_html = "{bucket}/wgs/{breed}/{sample_name}/{ref}/money/final_gather/vep/wags_{vep_interval}/{sample_name}.{vep_interval}.vep.vcf_summary.html", 
+        interval_vep      = "{bucket}/wgs/{breed}/{sample_name}/{ref}/money/final_gather/vep/wags_{vep_interval}/{sample_name}.{vep_interval}.vep.vcf.gz",
+        interval_vep_tbi  = "{bucket}/wgs/{breed}/{sample_name}/{ref}/money/final_gather/vep/wags_{vep_interval}/{sample_name}.{vep_interval}.vep.vcf.gz.tbi",
+        interval_vep_html = "{bucket}/wgs/{breed}/{sample_name}/{ref}/money/final_gather/vep/wags_{vep_interval}/{sample_name}.{vep_interval}.vep.vcf_summary.html",
     params:
         out_name = lambda wildcards, output: os.path.splitext(output.interval_vep)[0],
         ref_fasta = config["ref_fasta"],
-        ref_gtf   = config["ref_gtf"],
-        phylop    = config["phylop"],
+        ref_gtf   = config["ref_gtf"]
     threads: 6
     resources:
          time   = 720,
@@ -59,7 +58,6 @@ rule vep_by_interval:
                 -i {output.final_interval} \
                 -o {params.out_name} \
                 --gtf {params.ref_gtf} \
-                --custom file={params.phylop},short_name=PhyloP_score,format=bed,type=exact,coords=0 \
                 --fasta {params.ref_fasta} \
                 --fork {threads} \
                 --everything \


### PR DESCRIPTION
After comparing against other pipelines and reviewing git blame, it appears that `phylop` was added in a separate change unrelated to this local rule. Since there are no corresponding parameters for it in the config files, we removed it for OnlyWAG to run properly (local).