### PR TITLE
Fix `mark_duplicates` rule to support multiple users under `/dev/shm`

### DIFF
--- a/pipelines/one_wag/inputs/local/bqsr/rules/bam.smk
+++ b/pipelines/one_wag/inputs/local/bqsr/rules/bam.smk
@@ -55,7 +55,7 @@ rule mark_adapters:
     shell:
         '''
             mkdir -p {params.tmp_dir}
-            
+
             java -Xmx8G -jar /opt/wags/src/picard.jar  \
                 MarkIlluminaAdapters \
                 --INPUT {input.ubam} \
@@ -162,7 +162,7 @@ rule mark_duplicates:
             bucket=config['bucket'],
             breed=breed,
             sample_name=sample_name,
-            ref=config['ref'], 
+            ref=config['ref'],
             readgroup_name=list(units['readgroup_name']),
         )
     output:
@@ -171,7 +171,7 @@ rule mark_duplicates:
     params:
         bams       = lambda wildcards, input: " --INPUT ".join(map(str,input.merged_bams)),
         java_opt   = "-Xms4000m -Xmx16g",
-        tmp_dir    = "/dev/shm/{sample_name}_{ref}.md.tmp"
+        tmp_dir    = f"/dev/shm/{os.environ['USER']}/{sample_name}_{ref}.md.tmp"
     benchmark:
         "{bucket}/wgs/{breed}/{sample_name}/{ref}/bam/{sample_name}.mark_duplicates.benchmark.txt"
     threads: 4
@@ -319,7 +319,7 @@ rule gather_bqsr_reports:
                 -I {params.reports} \
                 -O {output.report}
         '''
-        
+
 rule apply_bqsr:
     input:
         sorted_bam = "{bucket}/wgs/{breed}/{sample_name}/{ref}/bam/{sample_name}.{ref}.aligned.duplicate_marked.sorted.bam"


### PR DESCRIPTION
The `mark_duplicates` rule was missing a user name parameter when creating shared memory under `/dev/shm`. Multiple users could not run samples with the same subject ID.